### PR TITLE
ACCESS_BACKGROUND_LOCATION の動作変更を確認

### DIFF
--- a/Location.md
+++ b/Location.md
@@ -1,0 +1,25 @@
+## Location updates in Android 11
+
+https://developer.android.com/preview/privacy/location
+
+### Background location access
+
+* ユーザが段階的に権限を許可することができるようにアプッリで Background location access の権限を許可できないようになった
+* Background location access の権限をリクエストするための手順は `targetSdkVersion` によって異なる
+
+#### Target Android 11
+
+* 直接 background location の常時アクセス権限をリクエストできない
+* その代わり、background での位置情報の取得がなぜ必要なのかをユーザに理解させるための UI を提供する
+* `getBackgroundPermissionOptionLabel`
+
+##### Limited requests for background location
+
+* リクエストが制限された場合でもアプリの設定ページへ遷移させることができる
+  * `Settigs.ACTION_APPLICATION_DETAILS_SETTINGS` を利用する
+  * ただし、この方法はユーザに説明がないので避けるべき
+
+#### Target Android 10
+
+* アプリ利用中のみで許可している場合はダイアログで継続するか、設定画面へ遷移するかどうかを選択させることができる
+  * ユーザが2回選択したらダイアログは表示されなくなる

--- a/OneTimePermissionSample/.idea/gradle.xml
+++ b/OneTimePermissionSample/.idea/gradle.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>

--- a/OneTimePermissionSample/app/src/main/AndroidManifest.xml
+++ b/OneTimePermissionSample/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.github.mag0716.onetimepermissionsample">
 
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_BACKGROUND_LOCATION" />
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.CAMERA" />
     <uses-permission android:name="android.permission.READ_CALENDAR" />

--- a/OneTimePermissionSample/app/src/main/java/com/github/mag0716/onetimepermissionsample/MainActivity.kt
+++ b/OneTimePermissionSample/app/src/main/java/com/github/mag0716/onetimepermissionsample/MainActivity.kt
@@ -58,18 +58,16 @@ class MainActivity : AppCompatActivity() {
         grantResults: IntArray
     ) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
-        Log.d(TAG, "onRequestPermissionResult : ${permissions[0]}, ${grantResults[0]}")
+        for ((index, permission) in permissions.withIndex()) {
+            Log.d(TAG, "onRequestPermissionResult : $permission, ${grantResults[index]}")
+        }
     }
 
     private fun requestPermission(features: Array<String>) {
-        val feature = features[0]
-        if (ContextCompat.checkSelfPermission(this, feature)
-            == PackageManager.PERMISSION_GRANTED
-        ) {
-            val t = arrayOf(features)
+        if (features.asSequence().all { isGranted(it) }) {
             Toast.makeText(
                 this,
-                "$feature's permission is granted.",
+                "${features.toList()} is granted.",
                 Toast.LENGTH_SHORT
             ).show()
         } else {
@@ -80,4 +78,7 @@ class MainActivity : AppCompatActivity() {
             )
         }
     }
+
+    private fun isGranted(feature: String) =
+        ContextCompat.checkSelfPermission(this, feature) == PackageManager.PERMISSION_GRANTED
 }

--- a/OneTimePermissionSample/app/src/main/java/com/github/mag0716/onetimepermissionsample/MainActivity.kt
+++ b/OneTimePermissionSample/app/src/main/java/com/github/mag0716/onetimepermissionsample/MainActivity.kt
@@ -2,6 +2,7 @@ package com.github.mag0716.onetimepermissionsample
 
 import android.Manifest
 import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
@@ -22,21 +23,32 @@ class MainActivity : AppCompatActivity() {
 
         // one-time permission が選択できる
         button1.setOnClickListener {
-            requestPermission(Manifest.permission.ACCESS_FINE_LOCATION)
+            val features = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                arrayOf(
+                    Manifest.permission.ACCESS_FINE_LOCATION,
+                    Manifest.permission.ACCESS_BACKGROUND_LOCATION
+                )
+            } else {
+                arrayOf(
+                    Manifest.permission.ACCESS_FINE_LOCATION
+                )
+            }
+            requestPermission(features)
+
         }
         button2.setOnClickListener {
-            requestPermission(Manifest.permission.RECORD_AUDIO)
+            requestPermission(arrayOf(Manifest.permission.RECORD_AUDIO))
         }
         button3.setOnClickListener {
-            requestPermission(Manifest.permission.CAMERA)
+            requestPermission(arrayOf(Manifest.permission.CAMERA))
         }
 
         // one-time permission が選択できない
         button4.setOnClickListener {
-            requestPermission(Manifest.permission.READ_CALENDAR)
+            requestPermission(arrayOf(Manifest.permission.READ_CALENDAR))
         }
         button5.setOnClickListener {
-            requestPermission(Manifest.permission.READ_CONTACTS)
+            requestPermission(arrayOf(Manifest.permission.READ_CONTACTS))
         }
     }
 
@@ -49,10 +61,12 @@ class MainActivity : AppCompatActivity() {
         Log.d(TAG, "onRequestPermissionResult : ${permissions[0]}, ${grantResults[0]}")
     }
 
-    private fun requestPermission(feature: String) {
+    private fun requestPermission(features: Array<String>) {
+        val feature = features[0]
         if (ContextCompat.checkSelfPermission(this, feature)
             == PackageManager.PERMISSION_GRANTED
         ) {
+            val t = arrayOf(features)
             Toast.makeText(
                 this,
                 "$feature's permission is granted.",
@@ -61,7 +75,7 @@ class MainActivity : AppCompatActivity() {
         } else {
             ActivityCompat.requestPermissions(
                 this,
-                arrayOf(feature),
+                features,
                 0
             )
         }


### PR DESCRIPTION
## 概要

Android 11 で ACCESS_BACKGROUND_LOCATION をリクエストしてもアプリ上でユーザが許可することができなくなった

## 動作確認結果

| Android 10 以下 | Android 11 |
| - | - |
| ![Screenshot_1583329707](https://user-images.githubusercontent.com/1555252/75886075-05cc2d00-5e6b-11ea-81ed-c53ca7fd2edd.png) | ![Screenshot_1583329793](https://user-images.githubusercontent.com/1555252/75886088-0b297780-5e6b-11ea-82bb-85843def7552.png) |

Allow in settings をタップで

![Screenshot_1583412016](https://user-images.githubusercontent.com/1555252/75982478-18596b80-5f2a-11ea-80e8-84dd42272a6f.png)

へ遷移する。
