### PR TITLE
[Package Visibility] preview3 以降での確認

### DIFF
--- a/references/Privacy updates/Package visibility.md
+++ b/references/Privacy updates/Package visibility.md
@@ -14,9 +14,26 @@ https://developer.android.com/preview/privacy/package-visibility
 * 以下のケースでは対応が不要
   * 自身のアプリがターゲット
   * 暗黙的 Intent で他アプリと連携している
-    * `resolveActivity()` を使うには `FLAG_ACTIVITY_REQUIRE_NOW_BROWSER`,`FLAG_ACTIVITY_REQUIRE_DEFAULT`の利用が必要になる
+    * `resolveActivity()` を使うには `FLAG_ACTIVITY_REQUIRE_NON_BROWSER`,`FLAG_ACTIVITY_REQUIRE_DEFAULT`の利用が必要になる
   * システムの設定や機能と連携している
   * ContentProvider を経由して他のアプリのデータと連携する
+
+### Add restrictions to activity starts
+
+* Android 11 ではフラグが追加されており、`ActivityNotFoundException` になるケースを指定できる
+  * このケースでは `resolveActivity()`, `queryIntentActivities()` を呼び出すべきではない
+  * 特に、Web に関する `Intent` で役立つ
+
+#### Launch a web intent in a non-browser app
+
+* `FLAG_ACTIVITY_REQUIRE_NON_BROWSER`
+  * ブラウザでないアプリが直接 `Intent` を扱える場合
+  * ユーザがダイアログでブラウザでないアプリを選択した場合
+
+#### Require only one matching activity
+
+* `FLAG_ACTIVITY_REQUIRE_DEFAULT`
+  * デバイスに `Intent` を扱えるアプリが1つしか存在しない、もしくはデフォルトアプリに設定されている場合のみ処理される
 
 ### Query and interact with specific packages
 
@@ -29,6 +46,13 @@ https://developer.android.com/preview/privacy/package-visibility
 ### Query and interact with all apps
 
 * Google Play のような全てのアプリと連携する必要があるアプリについては `QUERY_ALL_PACKAGES` を利用する
+
+### Log messages for package filtering
+
+* 以下のコマンドでログをフィルタリングすることが可能
+  * `adb shell pm log-visibility --enable your-package-name`
+  * `I/AppsFilter: interaction: PackageSetting{7654321 com.example.myapp/12345} -> PackageSetting{...} BLOCKED` のようなログが出力される
+* Caution: アプリのパフォーマンスに影響するのでテスト中以外は無効化すること
 
 ### Test the change
 

--- a/samples/PackageVisibilitySample/.idea/vcs.xml
+++ b/samples/PackageVisibilitySample/.idea/vcs.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$/../.." vcs="Git" />
     <mapping directory="$PROJECT_DIR$/.." vcs="Git" />
   </component>
 </project>

--- a/samples/PackageVisibilitySample/app/src/main/AndroidManifest.xml
+++ b/samples/PackageVisibilitySample/app/src/main/AndroidManifest.xml
@@ -2,11 +2,9 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.github.mag0716.packagevisibilitysample">
 
-    <!-- 確認のために追加してみたが preview2 の段階では影響していないように見えた
     <queries>
         <package android:name="com.github.mag0716.packagevisibility.target" />
     </queries>
-    -->
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
#5 でクラス名指定で別アプリ起動を行うようにしたが preview2 の時点では今まで通り起動ができた。
どういうケースで  `<queries>` の追加が必要なのかが不明だったので preview3 以降で調査する。