### PR TITLE
[Onetime permission] 実機で確認 -> ACCESS_BACKGROUND_LOCATION 説明用のダイアログを表示

### DIFF
--- a/samples/OneTimePermissionSample/app/src/main/java/com/github/mag0716/onetimepermissionsample/MainActivity.kt
+++ b/samples/OneTimePermissionSample/app/src/main/java/com/github/mag0716/onetimepermissionsample/MainActivity.kt
@@ -30,11 +30,29 @@ class MainActivity : AppCompatActivity(),
 
         // one-time permission が選択できる
         button1.setOnClickListener {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
+                shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION)
+            ) {
+                Toast.makeText(
+                    this,
+                    "show request ACCESS_FINE_LOCATION rationale",
+                    Toast.LENGTH_SHORT
+                ).show()
+                return@setOnClickListener
+            }
             requestPermission(arrayOf(Manifest.permission.ACCESS_FINE_LOCATION))
         }
         button2.setOnClickListener {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 if (isGranted(Manifest.permission.ACCESS_FINE_LOCATION)) {
+                    if (shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_BACKGROUND_LOCATION)) {
+                        Toast.makeText(
+                            this,
+                            "show request ACCESS_BACKGROUND_LOCATION rationale",
+                            Toast.LENGTH_SHORT
+                        ).show()
+                        return@setOnClickListener
+                    }
                     val dialogFragment = ExplainBackgroundLocationRequirementDialog()
                     dialogFragment.show(
                         supportFragmentManager,

--- a/samples/OneTimePermissionSample/app/src/main/java/com/github/mag0716/onetimepermissionsample/MainActivity.kt
+++ b/samples/OneTimePermissionSample/app/src/main/java/com/github/mag0716/onetimepermissionsample/MainActivity.kt
@@ -23,26 +23,19 @@ class MainActivity : AppCompatActivity() {
 
         // one-time permission が選択できる
         button1.setOnClickListener {
-//            val features = when {
-//                Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> {
-//                    // TODO: Android 11 preview1 - 3 ではクラッシュする
-//                    arrayOf(
-//                        Manifest.permission.ACCESS_FINE_LOCATION,
-//                        Manifest.permission.ACCESS_BACKGROUND_LOCATION
-//                    )
-//                }
-//                else -> {
-//                    arrayOf(
-//                        Manifest.permission.ACCESS_FINE_LOCATION
-//                    )
-//                }
-//            }
-//            requestPermission(features)
             requestPermission(arrayOf(Manifest.permission.ACCESS_FINE_LOCATION))
         }
         button2.setOnClickListener {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-                requestPermission(arrayOf(Manifest.permission.ACCESS_BACKGROUND_LOCATION))
+                if (isGranted(Manifest.permission.ACCESS_FINE_LOCATION)) {
+                    requestPermission(arrayOf(Manifest.permission.ACCESS_BACKGROUND_LOCATION))
+                } else {
+                    Toast.makeText(
+                        this,
+                        "must grant ACCESS_FINE_LOCATION",
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
             } else {
                 Toast.makeText(
                     this,

--- a/samples/OneTimePermissionSample/app/src/main/java/com/github/mag0716/onetimepermissionsample/MainActivity.kt
+++ b/samples/OneTimePermissionSample/app/src/main/java/com/github/mag0716/onetimepermissionsample/MainActivity.kt
@@ -1,24 +1,26 @@
 package com.github.mag0716.onetimepermissionsample
 
 import android.Manifest
-import android.annotation.TargetApi
 import android.app.Dialog
 import android.content.Context
 import android.content.DialogInterface
+import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
+import android.provider.Settings
 import android.util.Log
 import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.core.os.bundleOf
 import androidx.fragment.app.DialogFragment
 import kotlinx.android.synthetic.main.activity_main.*
 
 class MainActivity : AppCompatActivity(),
-    ExplainBackgroundLocationRequirementDialog.OnClickListener {
+    ExplainPermissionRequirementDialog.OnClickListener {
 
     companion object {
         private const val TAG = "OneTimePermission"
@@ -33,31 +35,31 @@ class MainActivity : AppCompatActivity(),
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M &&
                 shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_FINE_LOCATION)
             ) {
-                Toast.makeText(
-                    this,
-                    "show request ACCESS_FINE_LOCATION rationale",
-                    Toast.LENGTH_SHORT
-                ).show()
+                ExplainPermissionRequirementDialog.newInstance(Manifest.permission.ACCESS_FINE_LOCATION)
+                    .show(
+                        supportFragmentManager,
+                        ExplainPermissionRequirementDialog::class.java.simpleName
+                    )
                 return@setOnClickListener
             }
-            requestPermission(arrayOf(Manifest.permission.ACCESS_FINE_LOCATION))
+            requestPermission(Manifest.permission.ACCESS_FINE_LOCATION)
         }
         button2.setOnClickListener {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 if (isGranted(Manifest.permission.ACCESS_FINE_LOCATION)) {
                     if (shouldShowRequestPermissionRationale(Manifest.permission.ACCESS_BACKGROUND_LOCATION)) {
-                        Toast.makeText(
-                            this,
-                            "show request ACCESS_BACKGROUND_LOCATION rationale",
-                            Toast.LENGTH_SHORT
-                        ).show()
+                        ExplainPermissionRequirementDialog.newInstance(Manifest.permission.ACCESS_BACKGROUND_LOCATION)
+                            .show(
+                                supportFragmentManager,
+                                ExplainPermissionRequirementDialog::class.java.simpleName
+                            )
                         return@setOnClickListener
                     }
-                    val dialogFragment = ExplainBackgroundLocationRequirementDialog()
-                    dialogFragment.show(
-                        supportFragmentManager,
-                        ExplainBackgroundLocationRequirementDialog::class.java.simpleName
-                    )
+                    ExplainPermissionRequirementDialog.newInstance(Manifest.permission.ACCESS_FINE_LOCATION)
+                        .show(
+                            supportFragmentManager,
+                            ExplainPermissionRequirementDialog::class.java.simpleName
+                        )
                 } else {
                     Toast.makeText(
                         this,
@@ -75,18 +77,18 @@ class MainActivity : AppCompatActivity(),
         }
 
         button3.setOnClickListener {
-            requestPermission(arrayOf(Manifest.permission.RECORD_AUDIO))
+            requestPermission(Manifest.permission.RECORD_AUDIO)
         }
         button4.setOnClickListener {
-            requestPermission(arrayOf(Manifest.permission.CAMERA))
+            requestPermission(Manifest.permission.CAMERA)
         }
 
         // one-time permission が選択できない
         button5.setOnClickListener {
-            requestPermission(arrayOf(Manifest.permission.READ_CALENDAR))
+            requestPermission(Manifest.permission.READ_CALENDAR)
         }
         button6.setOnClickListener {
-            requestPermission(arrayOf(Manifest.permission.READ_CONTACTS))
+            requestPermission(Manifest.permission.READ_CONTACTS)
         }
     }
 
@@ -101,35 +103,49 @@ class MainActivity : AppCompatActivity(),
         }
     }
 
-    private fun requestPermission(features: Array<String>) {
-        if (features.asSequence().all { isGranted(it) }) {
+    override fun requestPermission(permission: String) {
+        if (isGranted(permission)) {
             Toast.makeText(
                 this,
-                "${features.toList()} is granted.",
+                "$permission is granted.",
                 Toast.LENGTH_SHORT
             ).show()
         } else {
             ActivityCompat.requestPermissions(
                 this,
-                features,
+                arrayOf(permission),
                 0
             )
         }
     }
 
+    override fun goToSettings() {
+        val intent = Intent().apply {
+            action = Settings.ACTION_APPLICATION_DETAILS_SETTINGS
+        }
+        startActivity(intent)
+    }
+
     private fun isGranted(feature: String) =
         ContextCompat.checkSelfPermission(this, feature) == PackageManager.PERMISSION_GRANTED
-
-    override fun onOkClicked() {
-        requestPermission(arrayOf(Manifest.permission.ACCESS_BACKGROUND_LOCATION))
-    }
 }
 
-@TargetApi(30)
-class ExplainBackgroundLocationRequirementDialog : DialogFragment() {
+class ExplainPermissionRequirementDialog : DialogFragment() {
 
     interface OnClickListener {
-        fun onOkClicked()
+        fun requestPermission(permission: String)
+        fun goToSettings()
+    }
+
+    companion object {
+        private const val KEY_PERMISSION = "Permission"
+        fun newInstance(permission: String): ExplainPermissionRequirementDialog {
+            return ExplainPermissionRequirementDialog().apply {
+                arguments = bundleOf(
+                    KEY_PERMISSION to permission
+                )
+            }
+        }
     }
 
     lateinit var listener: OnClickListener
@@ -143,15 +159,30 @@ class ExplainBackgroundLocationRequirementDialog : DialogFragment() {
         val activity = requireActivity()
         val packageManager = activity.application.packageManager
         val builder = AlertDialog.Builder(activity)
-        builder.setMessage(
-            """
-            機能を利用するためアプリ利用中以外でも位置情報の取得を行う必要があります。
-            設定画面で ${packageManager.backgroundPermissionOptionLabel} を選択して、位置情報の取得を許可してください。
-            """.trimIndent()
-        )
+        val permission = arguments?.getString(KEY_PERMISSION)
+            ?: throw IllegalArgumentException("must set argument.")
+        val message =
+            when (permission) {
+                Manifest.permission.ACCESS_BACKGROUND_LOCATION ->
+                    """
+                    機能を利用するためアプリ利用中以外でも位置情報の取得を行う必要があります。
+                    設定画面で ${packageManager.backgroundPermissionOptionLabel} を選択して、位置情報の取得を許可してください。
+                    """.trimIndent()
+                else ->
+                    """
+                    機能を利用するためには権限を許可いただく必要があります。
+                    設定画面より権限の許可をおこなってください。
+                    """.trimIndent()
+            }
+        builder.setMessage(message)
             .setNegativeButton("キャンセル", null)
             .setPositiveButton("OK") { _: DialogInterface, _: Int ->
-                listener.onOkClicked()
+                when (permission) {
+                    Manifest.permission.ACCESS_BACKGROUND_LOCATION -> listener.requestPermission(
+                        permission
+                    )
+                    else -> listener.goToSettings()
+                }
             }
         return builder.create()
     }

--- a/samples/OneTimePermissionSample/app/src/main/java/com/github/mag0716/onetimepermissionsample/MainActivity.kt
+++ b/samples/OneTimePermissionSample/app/src/main/java/com/github/mag0716/onetimepermissionsample/MainActivity.kt
@@ -1,17 +1,24 @@
 package com.github.mag0716.onetimepermissionsample
 
 import android.Manifest
+import android.annotation.TargetApi
+import android.app.Dialog
+import android.content.Context
+import android.content.DialogInterface
 import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.fragment.app.DialogFragment
 import kotlinx.android.synthetic.main.activity_main.*
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : AppCompatActivity(),
+    ExplainBackgroundLocationRequirementDialog.OnClickListener {
 
     companion object {
         private const val TAG = "OneTimePermission"
@@ -28,7 +35,11 @@ class MainActivity : AppCompatActivity() {
         button2.setOnClickListener {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 if (isGranted(Manifest.permission.ACCESS_FINE_LOCATION)) {
-                    requestPermission(arrayOf(Manifest.permission.ACCESS_BACKGROUND_LOCATION))
+                    val dialogFragment = ExplainBackgroundLocationRequirementDialog()
+                    dialogFragment.show(
+                        supportFragmentManager,
+                        ExplainBackgroundLocationRequirementDialog::class.java.simpleName
+                    )
                 } else {
                     Toast.makeText(
                         this,
@@ -90,4 +101,40 @@ class MainActivity : AppCompatActivity() {
 
     private fun isGranted(feature: String) =
         ContextCompat.checkSelfPermission(this, feature) == PackageManager.PERMISSION_GRANTED
+
+    override fun onOkClicked() {
+        requestPermission(arrayOf(Manifest.permission.ACCESS_BACKGROUND_LOCATION))
+    }
+}
+
+@TargetApi(30)
+class ExplainBackgroundLocationRequirementDialog : DialogFragment() {
+
+    interface OnClickListener {
+        fun onOkClicked()
+    }
+
+    lateinit var listener: OnClickListener
+
+    override fun onAttach(context: Context?) {
+        super.onAttach(context)
+        listener = context as OnClickListener
+    }
+
+    override fun onCreateDialog(savedInstanceState: Bundle?): Dialog {
+        val activity = requireActivity()
+        val packageManager = activity.application.packageManager
+        val builder = AlertDialog.Builder(activity)
+        builder.setMessage(
+            """
+            機能を利用するためアプリ利用中以外でも位置情報の取得を行う必要があります。
+            設定画面で ${packageManager.backgroundPermissionOptionLabel} を選択して、位置情報の取得を許可してください。
+            """.trimIndent()
+        )
+            .setNegativeButton("キャンセル", null)
+            .setPositiveButton("OK") { _: DialogInterface, _: Int ->
+                listener.onOkClicked()
+            }
+        return builder.create()
+    }
 }


### PR DESCRIPTION
## 概要

#3 でエミュレータで確認したが、preview2 以降でも `ACCESS_BACKGROUND_LOCATION` を他の権限と同時にリクエストすると正常に動作しない。
また、`ACCESS_BACKGROUND_LOCATION` 単体でリクエストすると端末の設定アプリへ遷移してしまい、端末の設定アプリへ遷移する導線を持ったダイアログが表示できていない。

## TODO

- [x] 実機で確認
   * Pixel3(11 preview4)でもクラッシュする
- [x] `ACCESS_BACKGROUND_LOCATION` リクエスト前にダイアログを表示する
    * `getBackgroundPermissionOptionLabel()`